### PR TITLE
Fix delete operations failing on 204 No Content responses

### DIFF
--- a/src/carddav/coroutines/delete-addressbook.rs
+++ b/src/carddav/coroutines/delete-addressbook.rs
@@ -1,12 +1,11 @@
 use io_stream::io::StreamIo;
-use serde::Deserialize;
 
-use crate::carddav::{config::CarddavConfig, request::Request, response::StatusResponse};
+use crate::carddav::{config::CarddavConfig, request::Request};
 
-use super::send::{Send, SendOk, SendResult};
+use super::send::{Empty, Send, SendResult};
 
 #[derive(Debug)]
-pub struct DeleteAddressbook(Send<Response>);
+pub struct DeleteAddressbook(Send<Empty>);
 
 impl DeleteAddressbook {
     const BODY: &'static str = "";
@@ -16,23 +15,7 @@ impl DeleteAddressbook {
         Self(Send::new(request, Self::BODY.as_bytes().to_vec()))
     }
 
-    pub fn resume(&mut self, arg: Option<StreamIo>) -> SendResult<bool> {
-        let ok = match self.0.resume(arg) {
-            SendResult::Ok(ok) => ok,
-            SendResult::Err(err) => return SendResult::Err(err),
-            SendResult::Io(io) => return SendResult::Io(io),
-        };
-
-        SendResult::Ok(SendOk {
-            request: ok.request,
-            response: ok.response,
-            keep_alive: ok.keep_alive,
-            body: ok.body.response.status.is_success(),
-        })
+    pub fn resume(&mut self, arg: Option<StreamIo>) -> SendResult<Empty> {
+        self.0.resume(arg)
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Response {
-    pub response: StatusResponse,
 }

--- a/src/carddav/coroutines/delete-card.rs
+++ b/src/carddav/coroutines/delete-card.rs
@@ -1,12 +1,11 @@
 use io_stream::io::StreamIo;
-use serde::Deserialize;
 
-use crate::carddav::{config::CarddavConfig, request::Request, response::StatusResponse};
+use crate::carddav::{config::CarddavConfig, request::Request};
 
-use super::send::{Send, SendOk, SendResult};
+use super::send::{Empty, Send, SendResult};
 
 #[derive(Debug)]
-pub struct DeleteCard(Send<Response>);
+pub struct DeleteCard(Send<Empty>);
 
 impl DeleteCard {
     const BODY: &'static str = "";
@@ -23,23 +22,7 @@ impl DeleteCard {
         Self(Send::new(request, Self::BODY.as_bytes().to_vec()))
     }
 
-    pub fn resume(&mut self, arg: Option<StreamIo>) -> SendResult<bool> {
-        let ok = match self.0.resume(arg) {
-            SendResult::Ok(ok) => ok,
-            SendResult::Err(err) => return SendResult::Err(err),
-            SendResult::Io(io) => return SendResult::Io(io),
-        };
-
-        SendResult::Ok(SendOk {
-            request: ok.request,
-            response: ok.response,
-            keep_alive: ok.keep_alive,
-            body: ok.body.response.status.is_success(),
-        })
+    pub fn resume(&mut self, arg: Option<StreamIo>) -> SendResult<Empty> {
+        self.0.resume(arg)
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Response {
-    pub response: StatusResponse,
 }


### PR DESCRIPTION
## Summary
- Switch `DeleteCard` and `DeleteAddressbook` from `Send<Response>` to `Send<Empty>`
- Handles servers (like Stalwart) that return `204 No Content` with an empty body on DELETE
- Matches the existing pattern used by `CreateCard`

Fixes #2

<details>
<summary>Context</summary>

I'm setting up a self-hosted PIM stack with Stalwart mail server. I already use himalaya for email and it works great. Now I want contacts and calendar management via CLI too, and found cardamum and calendula in the pimalaya project. I ran CRUD tests (create, list, read, update, delete) for both contacts and calendar items against my Stalwart instance and hit a few issues. Since I had the repos cloned locally I was able to fix them to get everything working.

Heads up: this issue (and PR if attached) was created with the help of Claude Code and hasn't been deeply reviewed on my end. If it's not useful or doesn't fit, feel free to close it — no hard feelings at all. If it looks interesting but needs more thought, ping me and I'll give it a proper review with my own eyes.

</details>