### PR TITLE
fix(carddav): add Content-Type XML header to PROPFIND requests

### DIFF
--- a/src/carddav/coroutines/addressbook-home-set.rs
+++ b/src/carddav/coroutines/addressbook-home-set.rs
@@ -21,7 +21,7 @@ impl AddressbookHomeSet {
     const BODY: &'static str = include_str!("./addressbook-home-set.xml");
 
     pub fn new(config: &CarddavConfig) -> Self {
-        let request = Request::propfind(config, "/");
+        let request = Request::propfind(config, "/").content_type_xml();
         let body = Self::BODY.as_bytes().into_iter().cloned();
         Self(FollowRedirects::new(request, body))
     }

--- a/src/carddav/coroutines/list-addressbooks.rs
+++ b/src/carddav/coroutines/list-addressbooks.rs
@@ -18,7 +18,7 @@ impl ListAddressbooks {
     const BODY: &'static str = include_str!("./list-addressbooks.xml");
 
     pub fn new(config: &CarddavConfig) -> Self {
-        let request = Request::propfind(config, "").depth(1);
+        let request = Request::propfind(config, "").content_type_xml().depth(1);
         let body = Self::BODY.as_bytes().into_iter().cloned();
         Self(Send::new(request, body))
     }


### PR DESCRIPTION
Fixes #4

`AddressbookHomeSet` and `ListAddressbooks` were missing `.content_type_xml()` on their PROPFIND requests. Servers like Fastmail (Cyrus) require the Content-Type header and return 415 Unsupported Media Type without it.

`CurrentUserPrincipal` already had the correct header — this just brings the other two PROPFIND coroutines in line.

Tested against Fastmail CardDAV — `cardamum addressbooks list` and `cardamum card list` both work after this fix.